### PR TITLE
Updated crfsuite lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/truefusion/usaddress",
   "dependencies": {
-    "crfsuite": "^0.9.3"
+    "crfsuite": "^1.0.1"
   },
   "files": [
     "usaddress/usaddr.crfsuite"

--- a/usaddress/index.js
+++ b/usaddress/index.js
@@ -117,7 +117,7 @@ const STREET_NAMES = new Set([
 
 module.exports = class usaddress {
 	constructor(model) {;
-		this.TAGGER = crfsuite.Tagger();
+		this.TAGGER = new crfsuite.Tagger();
 		this.open(model || __dirname + '/' + 'usaddr.crfsuite');
 	}
 


### PR DESCRIPTION
Updated the CrfSuite lib to latest 1.0.1. It works with the existing model served in the usaddress npm package. 